### PR TITLE
feat: handle lazyLoading improve code quality and image handling

### DIFF
--- a/src/components/LightGallery.astro
+++ b/src/components/LightGallery.astro
@@ -13,7 +13,7 @@ const {
   options = {},     // https://www.lightgalleryjs.com/docs/settings/
   addPlugins = [],
   id = `astro-lightgallery-${Math.random().toString(36).slice(2, 11)}`,
-  class: className = null,
+  class: className,
   layout,
   ...props
 } = Astro.props;
@@ -23,24 +23,11 @@ const paramLayout = layout ? (({ imgs, ...o }) => o)(layout) : {}    // remove i
 const classContainer = layout?.classContainer ?? null
 const classItem = layout?.classItem ??  null
 
-// update missing informations (if any) in layout.imgs
-if (layout) {
-  layout.imgs.forEach(img => {
-    if (!img.srcThumb) {
-      img.srcThumb = img.src
-    }
-    if (!img.alt) {
-      img.alt = ''
-    }
-  })
-}
-
 ---
 <!-- slot is provided, that means that the user is using his gallery layout
      only provide lightgallery setup
   -->
 { Astro.slots.has('default') && (
-
   <astro-lightgallery
     id={id}
     class={className}
@@ -52,13 +39,13 @@ if (layout) {
     >
       <slot />
   </astro-lightgallery>
-) }
+)}
 
 <!-- slot is not provided, that means that the user is using the gallery layout of astro-gallery
      the description of this layout is provided in layout, including the images
   -->
 
-{ !Astro.slots.has('default') && (layout !== undefined) && (
+{!Astro.slots.has('default') && (layout !== undefined) && (
   <astro-lightgallery
     id={id}
     class:list={['astro-lightgallery-adaptive-container', className, classContainer]}
@@ -68,20 +55,23 @@ if (layout) {
     data-addplugins={JSON.stringify(addPlugins)}
     data-param-layout={JSON.stringify(paramLayout)}
     >
-
     {
-      // TODO: also use Image from astro if this is possible
+      // TODO: use Image from astro if this is possible
       layout.imgs.map(img => (
         <a
           class:list={['astro-lightgallery-adaptive-item', classItem]}
           href={img.src}
           data-sub-html={(img.subHtml ? img.subHtml : '')}>
-            <img src={img.srcThumb} alt={img.alt} />
+            <img 
+              src={img?.srcThumb ?? img.src} 
+              alt={img?.alt ?? ''} 
+              loading={img.loading ?? 'lazy'} 
+            />
         </a>
       ))
     }
   </astro-lightgallery>
-) }
+)}
 
 
 <script>

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,9 @@ type LightGalleryAllSettingsFix = LightGalleryAllSettings & RelativeCaptionSetti
 type LightGallerySettingsFix = Partial<LightGalleryAllSettingsFix>;
 
 /** List of images, and their attributes, to be displayed in a provided layout */
-export interface AstroLightGalleryImgType extends Partial<Pick<HTMLAttributes<"img">, 'src' | 'loading' | 'alt'>> {
+export interface AstroLightGalleryImgType extends Partial<Pick<HTMLAttributes<"img">, 'loading' | 'alt'>> {
+    /** the source of the large image */
+  src: string,
   /** the source of the thumbnail image. If not provided, use src (the large one) */
   srcThumb?: string
   /* caption for the slide, if any */

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ export type AstroLightGalleryPluginStrType = (
   'video' |
   'vimeoThumbnail' |
   'zoom'
-  )
+)
 
 /**
  * Fix in atro-lightgallery missing plugin settings in LightGallerySettings
@@ -39,15 +39,11 @@ type LightGalleryAllSettingsFix = LightGalleryAllSettings & RelativeCaptionSetti
 type LightGallerySettingsFix = Partial<LightGalleryAllSettingsFix>;
 
 /** List of images, and their attributes, to be displayed in a provided layout */
-export interface AstroLightGalleryImgType extends Partial<Pick<HTMLAttributes<"img">, 'loading' | 'alt'>> {
-  /** the source of the large image */
-  src: string,
-
+export interface AstroLightGalleryImgType extends Partial<Pick<HTMLAttributes<"img">, 'src' | 'loading' | 'alt'>> {
   /** the source of the thumbnail image. If not provided, use src (the large one) */
   srcThumb?: string
-
   /* caption for the slide, if any */
-  subHtml?:string
+  subHtml?: string
 }
 
 /** Layout parameters, when the user wants to use an existing layout
@@ -64,7 +60,7 @@ export interface AstroLightGalleryLayoutType {
     /** zoom factor (100 by default) to enlarge or reduce the gallery
      * with respect to the original size provided by the layout
      */
-    zoom?:number,
+    zoom?: number,
   }
 
   /** classContainer, to be defined by the user in case he wants
@@ -104,20 +100,21 @@ export { default as LightGallery } from './components/LightGallery.astro'
 
 function _textColor(text: string, color: string) {
   let colorCode: string
-  if      (color === 'FgRed')    { colorCode = '\x1b[31m' }
-  else if (color === 'FgBlue')   { colorCode = '\x1b[34m' }
-  else if (color === 'FgGreen')  { colorCode = '\x1b[32m' }
+  if (color === 'FgRed') { colorCode = '\x1b[31m' }
+  else if (color === 'FgBlue') { colorCode = '\x1b[34m' }
+  else if (color === 'FgGreen') { colorCode = '\x1b[32m' }
   else if (color === 'FgYellow') { colorCode = '\x1b[33m' }
-  else if (color === 'FgCyan')   { colorCode = '\x1b[36m' }
+  else if (color === 'FgCyan') { colorCode = '\x1b[36m' }
   else { colorCode = '\x1b[31m' }   // red by default
 
   return `${colorCode + text}\x1b[0m`
 }
 
-async function _addPlugin(plugins: (new (instance: LightGallery, $LG: LgQuery) => unknown)[], pluginStr: AstroLightGalleryPluginStrType) {
-  console.log(_textColor(`astro-lightgallery: add plugin ${pluginStr}`, 'FgGreen'))
-  let plugin = undefined
-  switch (pluginStr) {
+async function _addPlugin(plugins: (new (instance: LightGallery, $LG: LgQuery) => unknown)[], pluginType: AstroLightGalleryPluginStrType) {
+  console.log(_textColor(`astro-lightgallery: add plugin ${pluginType}`, 'FgGreen'))
+  let plugin = undefined;
+  
+  switch (pluginType) {
     case 'thumbnail':
       plugin = await import('lightgallery/plugins/thumbnail')
       break
@@ -158,18 +155,19 @@ async function _addPlugin(plugins: (new (instance: LightGallery, $LG: LgQuery) =
       plugin = await import('lightgallery/plugins/zoom')
       break
     default:
-      console.log(_textColor(`astro-lightgallery: failed adding unknown plugin ${pluginStr}`, 'FgRed'))
+      console.log(_textColor(`astro-lightgallery: failed adding unknown plugin ${pluginType}`, 'FgRed'))
       break
   }
-  if (plugin !== undefined) {
-    plugins.push(plugin.default)
+
+  if (plugin != null){
+     plugins.push(plugin.default)
   }
 }
 
 export async function createLightGallery(id: string, options: LightGallerySettings, addPlugins: AstroLightGalleryPluginStrType[]): Promise<LightGallery | undefined> {
   const plugins: (new (instance: LightGallery, $LG: LgQuery) => unknown)[] = []
   const el = document.getElementById(id)
-  if (!el) {
+  if (!el){
     return undefined
   }
 


### PR DESCRIPTION
This PR clean the class checks and conditions. But also extend the native functionalities of img as of handling the native lazyLoading per main img and the thumbnails.

Follow up on closed https://github.com/pascal-brand38/astro-lightGallery/pull/3

feat:

- remove unnecessary image attribute initialization logic from component
- implement optional chaining and nullish coalescing for image attributes (srcThumb, alt, loading)