### PR TITLE
fix: replace Math.random with crypto API for ID generation

### DIFF
--- a/src/components/LightGallery.astro
+++ b/src/components/LightGallery.astro
@@ -12,7 +12,7 @@ type Props = AstroLightGalleryType
 const {
   options = {},     // https://www.lightgalleryjs.com/docs/settings/
   addPlugins = [],
-  id = `astro-lightgallery-${crypto.randomUUID().replace(/-/g, '_')}`,
+  id = `astro-lightgallery-${crypto.randomUUID()}`,
   class: className = null,
   layout,
   ...props

--- a/src/components/LightGallery.astro
+++ b/src/components/LightGallery.astro
@@ -12,7 +12,7 @@ type Props = AstroLightGalleryType
 const {
   options = {},     // https://www.lightgalleryjs.com/docs/settings/
   addPlugins = [],
-  id = `astro-lightgallery-${Math.random().toString(36).slice(2, 11)}`,
+  id = `astro-lightgallery-${crypto.randomUUID().replace(/-/g, '_')}`,
   class: className = null,
   layout,
   ...props


### PR DESCRIPTION
Improve ID generation reliability and uniqueness using standard crypto API, it ensures consistent and cryptographically secure random ID generation for gallery instances. 
It also may improve performance as we skip additional transformations.